### PR TITLE
Use name to getFlag instead geoId

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,8 +26,8 @@ export const DEFAULT_OPTIONS = {
 
 export const DEFAULT_COUNTRIES = [
   "Brazil",
-  "United_States_of_America",
-  "United_Kingdom",
+  "United States",
+  "United Kingdom",
   "China",
   "Sweden",
   "Spain",
@@ -36,7 +36,7 @@ export const DEFAULT_COUNTRIES = [
   "Canada",
   "Portugal",
   "Italy",
-  "South_Korea",
+  "South Korea",
   "Iran",
   "Israel",
   "Netherlands",

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -73,5 +73,5 @@ function getFlag(data: Pick<MetadataCountry, "name" | "geoId">) {
     return 'greece';
   }
 
-  return data.geoId.toLowerCase() as FlagNameValues;
+  return data.name.toLowerCase() as FlagNameValues;
 }


### PR DESCRIPTION
**:warning: WARNING :warning:**

- This PR must be accepted after [inf-covid19/data/!16](https://github.com/inf-covid19/data/pull/16)

Since inf-covid19/data countries source has changed, this PR update `getFlag` function to use name instead of a deprecated attribute (geoId)